### PR TITLE
page monitor now can change name and group

### DIFF
--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Controllers/MonitorController.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Controllers/MonitorController.java
@@ -28,7 +28,7 @@ public class MonitorController {
         this.monitorService = monitorService;
     }
 
-    @Operation(summary = "Get all monitors")
+    @Operation(summary = "Get all monitors not Pending")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "List of all monitors", content = @Content(mediaType = "application/json")),
     })

--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Controllers/MonitorController.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Controllers/MonitorController.java
@@ -30,7 +30,7 @@ public class MonitorController {
 
     @Operation(summary = "Get all monitors not Pending")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "List of all monitors", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "200", description = "List of all monitors that are not pending", content = @Content(mediaType = "application/json")),
     })
     @GetMapping
     public ResponseEntity<?> getAllMonitors() {

--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Services/MonitorService.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Services/MonitorService.java
@@ -3,15 +3,9 @@ package deti.uas.uasmartsignage.Services;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import deti.uas.uasmartsignage.Repositories.MonitorGroupRepository;
 import deti.uas.uasmartsignage.Repositories.MonitorRepository;
 import deti.uas.uasmartsignage.Models.Monitor;
-import deti.uas.uasmartsignage.Models.MonitorsGroup;
-import deti.uas.uasmartsignage.Services.MonitorGroupService;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import deti.uas.uasmartsignage.Configuration.MqttConfig;
-import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 
 import java.util.List;
@@ -19,18 +13,11 @@ import java.util.List;
 @Service 
 public class MonitorService {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
-    private final MonitorGroupService MonitorGroupService;
-
-    
-
     private final MonitorRepository monitorRepository;
 
     @Autowired
-    public MonitorService(MonitorRepository monitorRepository, MonitorGroupService monitorGroupService){
+    public MonitorService(MonitorRepository monitorRepository, MonitorGroupRepository monitorGroupRepository){
         this.monitorRepository = monitorRepository;
-        this.MonitorGroupService = monitorGroupService;
     }
 
     public Monitor getMonitorById(Long id) {
@@ -50,8 +37,6 @@ public class MonitorService {
         if (monitorById == null) {
             return null;
         }
-        monitorById.setName(monitor.getName());
-        monitorById.setGroup(monitor.getGroup());
         monitorById.setName(monitor.getName());
         monitorById.setGroup(monitor.getGroup());
         return monitorRepository.save(monitorById);

--- a/backend/uasmartsignage/src/test/java/deti/uas/uasmartsignage/serviceTests/MonitorServiceTest.java
+++ b/backend/uasmartsignage/src/test/java/deti/uas/uasmartsignage/serviceTests/MonitorServiceTest.java
@@ -2,8 +2,6 @@ package deti.uas.uasmartsignage.serviceTests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -14,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import deti.uas.uasmartsignage.Models.Monitor;

--- a/frontend/src/components/PageTitle/StartTitleHtml.jsx
+++ b/frontend/src/components/PageTitle/StartTitleHtml.jsx
@@ -1,4 +1,4 @@
-import { MdAccountCircle, MdInfoOutline } from "react-icons/md";
+import { MdAccountCircle, MdInfoOutline, MdMonitor } from "react-icons/md";
 
 
 function StartTitleHtml( {page} ){
@@ -24,6 +24,13 @@ function StartTitleHtml( {page} ){
             <span className="font-bold text-3xl flex flex-row place-content-end items-end">
                 Schedule
                 <MdInfoOutline className="ml-2 w-6 cursor-pointer"/>
+            </span>
+    )
+    if (page === "monitor")
+        return(
+            <span className="font-bold text-3xl flex flex-row place-content-end items-end">
+                <MdMonitor className="mx-2 text-4xl"/>
+                Monitor
             </span>
     )
 }

--- a/frontend/src/pages/Monitor/index.jsx
+++ b/frontend/src/pages/Monitor/index.jsx
@@ -1,94 +1,150 @@
+import { useEffect, useState } from "react";
 import { PageTitle, MemorySvg } from "../../components";
-import { MdCreate, MdArrowBack, MdMonitor } from "react-icons/md";
-import { useLocation } from "react-router";
+import { MdCreate, MdArrowBack, MdMonitor,MdCheck } from "react-icons/md";
+import { useLocation, useParams } from "react-router";
+import monitorService from "../../services/monitorService";
+import monitorsGroupService from "../../services/monitorsGroupService";
 
 
 function Monitor(){
     const { state } = useLocation();
-    const monitor = state;
+    const [monitor,setMonitor] = useState(state);
+    const [name,setName] = useState("");
+    const [groupId,setGroupId] = useState();
+    const [groups,setGroups] = useState([]);
+    const { id } = useParams();
+    const [Update,setUpdate] = useState(false);
 
-    return(
-        <div className="h-full flex flex-col">
-            <div id="title" className="pt-4 h-[8%]">
-                <PageTitle startTitle={"dashboard"} 
-                            middleTitle={"dashboard"}
-                            endTitle={"dashboard"}/>
-            </div>
-            <div id="monitor" className="h-[92%]">
-                <div className="h-[8%] w-full flex flex-row">
-                    <div className="w-[50%] flex text-2xl gap-2 pb-2 items-end"><MdArrowBack className=" size-8"/> Go Back</div>
-                    <div className="w-[50%] flex text-2xl gap-2 pb-2 pl-4 items-end"><MdMonitor className=" size-8"/>Preview</div>
+    useEffect(()=>{
+        monitorService.getMonitorById(id).then((response)=>{
+            setMonitor(response.data)
+            setName(response.data.name)
+            setGroupId(response.data.group.id)
+        monitorsGroupService.getGroups().then((response)=>{
+            setGroups(response.data)
+        })
+        })
+    },[])
+
+    const handleUpdate = ()=>{
+        monitor.name = name
+        monitor.group = groups.find((element)=>element.id == groupId)
+        monitorService.updateMonitor(id,monitor).then((response)=>{
+            setMonitor(response.data)
+        })
+        setUpdate(false)
+    }
+
+    
+    if(monitor !== null)
+        return(
+            <div className="h-full flex flex-col">
+                <div id="title" className="pt-4 h-[8%]">
+                    <PageTitle startTitle={"monitor"} 
+                                middleTitle={"dashboard"}
+                                endTitle={"dashboard"}/>
                 </div>
-                <div className="h-[92%] w-full flex flex-row gap-5">
-                    <div className="w-[50%] h-full bg-secondaryLight rounded-[30px] flex flex-col p-5 gap-5">
-                        <span className=" text-center text-3xl flex flex-row items-center justify-center gap-4">{monitor.name}<MdCreate/></span>
-                        <div className=" bg-secondaryMedium rounded-[20px] h-[30%] text-center flex flex-col p-4 pb-6">
-                            <p className="text-3xl">Template</p>
-                            <p className="m-auto text-xl">DUMMY VALUE</p>
-                        </div>
-                        <div className="h-[60%] flex-col flex gap-3 text-center text-xl">
-                            <div className="flex w-full gap-3 h-[49%] justify-around">
-                                <div className=" bg-secondaryMedium rounded-[10px] rounded-tl-[30px] basis-1/3 flex flex-col items-center p-2 h-full"> 
-                                    <div className="h-[20%]">Memory</div>
-                                    <MemorySvg className=" h-[80%]" usado={"120"} max={`${monitor.size}`} full={0.5}/>
-                                </div>
-                                <div className=" bg-secondaryMedium rounded-[10px] basis-1/3 p-2"> 
-                                    <div className="h-[20%]">
-                                        <span>IP</span>
+                <div id="monitor" className="h-[92%]">
+                    <div className="h-[8%] w-full flex flex-row">
+                        <div className="w-[50%] flex text-2xl gap-2 pb-2 items-end"><MdArrowBack className=" size-8"/> Go Back</div>
+                        <div className="w-[50%] flex text-2xl gap-2 pb-2 pl-4 items-end"><MdMonitor className=" size-8"/>Preview</div>
+                    </div>
+                    <div className="h-[92%] w-full flex flex-row gap-5">
+                        <div className="w-[50%] h-full bg-secondaryLight rounded-[30px] flex flex-col p-5 gap-5">
+                            <div className=" text-center text-4xl flex flex-row items-center justify-center gap-4">
+                                {Update ? 
+                                    <div className="rounded-lg bg-secondaryMedium px-2 flex flex-row items-center">
+                                        <input className="bg-secondaryMedium rounded-lg" value={name} onChange={(e)=>setName(e.target.value)}></input>
+                                        <MdCreate className="ml-auto text-2xl text-gray-500"/>
                                     </div>
-                                    <div className="h-[80%] flex items-center w-full pb-[20%]">
-                                        <span className="text-xl text-center w-full">{monitor.ip}</span>
-                                    </div>
-                                </div>
-                                <div className=" bg-secondaryMedium rounded-[10px] rounded-tr-[30px] basis-1/3 p-2"> 
-                                    <div className="h-[20%]">
-                                        <span className="flex flex-row gap-2 justify-center items-center">Group<MdCreate/></span>
-                                    </div>
-                                    <div className="h-[80%] flex items-center w-full pb-[20%]">
-                                        <span className="text-xl text-center w-full">{monitor.group.name}</span>
-                                    </div>
-                                </div>
-
+                                    :
+                                    <div className="">{monitor.name}</div>
+                                }
+                                {Update ? 
+                                    <MdCheck className="transition ml-auto cursor-pointer text-3xl hover:text-4xl hover:translate-y-[-5px] hover:translate-x-1" onClick={()=>handleUpdate()}/>
+                                    :
+                                    <MdCreate className="transition ml-auto cursor-pointer text-3xl hover:text-4xl hover:translate-y-[-5px] hover:translate-x-1" onClick={()=>setUpdate(true)}/>
+                                }
                             </div>
-                            <div className="flex w-full gap-3 h-[49%] justify-around">
-                                <div className=" bg-secondaryMedium rounded-[10px] rounded-bl-[30px] basis-1/3 p-2"> 
-                                    <div className="h-[20%]">
-                                        <span>Updated</span>
+                            <div className=" bg-secondaryMedium rounded-[20px] h-[30%] text-center flex flex-col p-4 pb-6">
+                                <p className="text-3xl">Template</p>
+                                <p className="m-auto text-xl">DUMMY VALUE</p>
+                            </div>
+                            <div className="h-[60%] flex-col flex gap-3 text-center text-xl">
+                                <div className="flex w-full gap-3 h-[49%] justify-around">
+                                    <div className=" bg-secondaryMedium rounded-[10px] rounded-tl-[30px] basis-1/3 flex flex-col items-center p-2 h-full"> 
+                                        <div className="h-[20%]">Memory</div>
+                                        <MemorySvg className=" h-[80%]" usado={"120"} max={`${monitor.size}`} full={0.5}/>
                                     </div>
-                                    <div className="h-[80%] flex items-center w-full pb-[20%]">
-                                        <span className="text-xl text-center w-full">DUMMY VALUE</span>
+                                    <div className=" bg-secondaryMedium rounded-[10px] basis-1/3 p-2"> 
+                                        <div className="h-[20%]">
+                                            <span>IP</span>
+                                        </div>
+                                        <div className="h-[80%] flex items-center w-full pb-[20%]">
+                                            <span className="text-xl text-center w-full">{monitor.ip}</span>
+                                        </div>
+                                    </div>
+                                    <div className=" bg-secondaryMedium rounded-[10px] rounded-tr-[30px] basis-1/3 p-2"> 
+                                        <div className="h-[20%]">
+                                            <span className="flex flex-row gap-2 justify-center items-center">Group</span>
+                                        </div>
+                                        <div className="h-[80%] flex items-center w-full pb-[20%]">
+                                            {Update?
+                                                <select className="rounded-lg bg-secondaryLight p-2 w-[80%] mx-auto" onChange={e => setGroupId(e.target.value)}>
+                                                    {groups.map((group)=>
+                                                    <option value={group.id} selected={groupId== group.id}>{group.name}</option>
+                                                )}
+                                                </select>
+                                                :
+                                                <span className="text-xl text-center w-full">{monitor.group.name}</span>
+                                            }
+                                        </div>
+                                    </div>
+
+                                </div>
+                                <div className="flex w-full gap-3 h-[49%] justify-around">
+                                    <div className=" bg-secondaryMedium rounded-[10px] rounded-bl-[30px] basis-1/3 p-2"> 
+                                        <div className="h-[20%]">
+                                            <span>Updated</span>
+                                        </div>
+                                        <div className="h-[80%] flex items-center w-full pb-[20%]">
+                                            <span className="text-xl text-center w-full">DUMMY VALUE</span>
+                                        </div>
+                                    </div>
+                                    <div className=" bg-secondaryMedium rounded-[10px] basis-1/3 p-2"> 
+                                        <div className="h-[20%]">
+                                            <span>Errors</span>
+                                        </div>
+                                        <div className="h-[80%] flex items-center w-full pb-[20%]">
+                                            <span className="text-xl text-center w-full">DUMMY VALUE</span>
+                                        </div>
+                                    </div>
+                                    <div className=" bg-secondaryMedium rounded-[10px] rounded-br-[30px] basis-1/3 p-2"> 
+                                        <div className="h-[20%]">
+                                            <span>Last Update</span>
+                                        </div>
+                                        <div className="h-[80%] flex items-center w-full pb-[20%]">
+                                            <span className="text-xl text-center w-full">DUMMY VALUE</span>
+                                        </div>
                                     </div>
                                 </div>
-                                <div className=" bg-secondaryMedium rounded-[10px] basis-1/3 p-2"> 
-                                    <div className="h-[20%]">
-                                        <span>Errors</span>
-                                    </div>
-                                    <div className="h-[80%] flex items-center w-full pb-[20%]">
-                                        <span className="text-xl text-center w-full">DUMMY VALUE</span>
-                                    </div>
-                                </div>
-                                <div className=" bg-secondaryMedium rounded-[10px] rounded-br-[30px] basis-1/3 p-2"> 
-                                    <div className="h-[20%]">
-                                        <span>Last Update</span>
-                                    </div>
-                                    <div className="h-[80%] flex items-center w-full pb-[20%]">
-                                        <span className="text-xl text-center w-full">DUMMY VALUE</span>
-                                    </div>
-                                </div>
+                            </div>
+                        </div>
+                        <div className="w-[50%] h-full">
+                            <div className="h-[60%] bg-secondaryLight rounded-[30px] p-3 w-full">
+                                <img src="https://w.wallhaven.cc/full/ex/wallhaven-exrqrr.jpg" className="h-full w-full  rounded-[20px]">
+
+                                </img>
                             </div>
                         </div>
                     </div>
-                    <div className="w-[50%] h-full">
-                        <div className="h-[60%] bg-secondaryLight rounded-[30px] p-3 w-full">
-                            <img src="https://w.wallhaven.cc/full/ex/wallhaven-exrqrr.jpg" className="h-full w-full  rounded-[20px]">
-
-                            </img>
-                        </div>
-                    </div>
                 </div>
             </div>
-        </div>
-    )
+        )
+    else
+        return(
+            <div>Loading</div>
+        )
 }
 
 export default Monitor;

--- a/frontend/src/pages/Monitor/index.jsx
+++ b/frontend/src/pages/Monitor/index.jsx
@@ -13,16 +13,16 @@ function Monitor(){
     const [groupId,setGroupId] = useState();
     const [groups,setGroups] = useState([]);
     const { id } = useParams();
-    const [Update,setUpdate] = useState(false);
+    const [update,setUpdate] = useState(false);
 
     useEffect(()=>{
         monitorService.getMonitorById(id).then((response)=>{
             setMonitor(response.data)
             setName(response.data.name)
             setGroupId(response.data.group.id)
+        })
         monitorsGroupService.getGroups().then((response)=>{
             setGroups(response.data)
-        })
         })
     },[])
 
@@ -52,7 +52,7 @@ function Monitor(){
                     <div className="h-[92%] w-full flex flex-row gap-5">
                         <div className="w-[50%] h-full bg-secondaryLight rounded-[30px] flex flex-col p-5 gap-5">
                             <div className=" text-center text-4xl flex flex-row items-center justify-center gap-4">
-                                {Update ? 
+                                {update ? 
                                     <div className="rounded-lg bg-secondaryMedium px-2 flex flex-row items-center">
                                         <input className="bg-secondaryMedium rounded-lg" value={name} onChange={(e)=>setName(e.target.value)}></input>
                                         <MdCreate className="ml-auto text-2xl text-gray-500"/>
@@ -60,7 +60,7 @@ function Monitor(){
                                     :
                                     <div className="">{monitor.name}</div>
                                 }
-                                {Update ? 
+                                {update ? 
                                     <MdCheck className="transition ml-auto cursor-pointer text-3xl hover:text-4xl hover:translate-y-[-5px] hover:translate-x-1" onClick={()=>handleUpdate()}/>
                                     :
                                     <MdCreate className="transition ml-auto cursor-pointer text-3xl hover:text-4xl hover:translate-y-[-5px] hover:translate-x-1" onClick={()=>setUpdate(true)}/>
@@ -89,10 +89,10 @@ function Monitor(){
                                             <span className="flex flex-row gap-2 justify-center items-center">Group</span>
                                         </div>
                                         <div className="h-[80%] flex items-center w-full pb-[20%]">
-                                            {Update?
+                                            {update?
                                                 <select className="rounded-lg bg-secondaryLight p-2 w-[80%] mx-auto" onChange={e => setGroupId(e.target.value)}>
                                                     {groups.map((group)=>
-                                                    <option value={group.id} selected={groupId== group.id}>{group.name}</option>
+                                                    <option key={group.id} value={group.id} selected={groupId== group.id}>{group.name}</option>
                                                 )}
                                                 </select>
                                                 :

--- a/frontend/src/pages/Monitors/index.jsx
+++ b/frontend/src/pages/Monitors/index.jsx
@@ -27,10 +27,17 @@ function Monitors(){
 
 
     const customStyles = {
+        headRow: {
+            style: {
+                minHeight: '40px',
+                borderBottomWidth: '1px',
+                borderBottomStyle: 'solid',
+            },
+        },
         rows: {
             style: {
                 
-                minHeight: '72px', // override the row height
+                minHeight: '40px', // override the row height
             },
         },
         headCells: {

--- a/frontend/src/services/monitorService.jsx
+++ b/frontend/src/services/monitorService.jsx
@@ -20,6 +20,9 @@ const monitorService = {
     },
     async acceptMonitor(id){
         return await client.put(`/monitors/accept/${id}`)
+    },
+    async updateMonitor(id,monitor){
+        return await client.put(`/monitors/${id}`,monitor)
     }
 }
 


### PR DESCRIPTION
### Issue

Closes #81 
### Reason for this change

This change makes that the page monitors have information of the backend and it permit change the name anda the group of monitor.

### Description of changes

In the backend i changed the update in the service.
In frontend changed the page monitor it recives some chache from page monitors to load faster but then it fetchs data from api.
The page now supports updating the name of monitor with input field and the group with select field (in futer we can add a search bar for the select).

### Description of how you validated changes

The backend changes passes the unit tests.
The frontend was tested manualy changing the name and group of the monitor.

### Checklist
- [x] I have tested my changes locally.
- [ ] I have updated the documentation to reflect my changes.
- [x] I have added/updated unit tests (if applicable).
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://ua-smart-signage-platform.github.io/Documentation-Website/guidelines/)

### Aditional Information


