### PR TITLE
Add functionality to preview media files and better its page visual aspect

### DIFF
--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Configuration/MvcConfig.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Configuration/MvcConfig.java
@@ -10,6 +10,8 @@ public class MvcConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry
             .addResourceHandler("/uploads/**")
-            .addResourceLocations("file:uploads/");
+            .addResourceLocations("file:uploads/")
+            .setCachePeriod(500)
+            .resourceChain(true);
     }
 }

--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Configuration/MvcConfig.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Configuration/MvcConfig.java
@@ -1,0 +1,15 @@
+package deti.uas.uasmartsignage.Configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry
+            .addResourceHandler("/uploads/**")
+            .addResourceLocations("file:uploads/");
+    }
+}

--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/initializer/DataLoader.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/initializer/DataLoader.java
@@ -224,7 +224,7 @@ public class DataLoader implements CommandLineRunner {
         // create the widget mappings for template 2
         temperature = new TemplateWidget();
         temperature.setTop(0);
-        temperature.setLeftPosition(0);
+        temperature.setLeftPosition(80);
         temperature.setHeight(20);
         temperature.setWidth(20);
         temperature.setTemplate(template2);
@@ -233,7 +233,7 @@ public class DataLoader implements CommandLineRunner {
 
         video = new TemplateWidget();
         video.setTop(0);
-        video.setLeftPosition(20);
+        video.setLeftPosition(0);
         video.setHeight(90);
         video.setWidth(80);
         video.setTemplate(template2);
@@ -251,7 +251,7 @@ public class DataLoader implements CommandLineRunner {
 
         image = new TemplateWidget();
         image.setTop(20);
-        image.setLeftPosition(0);
+        image.setLeftPosition(80);
         image.setHeight(70);
         image.setWidth(20);
         image.setTemplate(template2);

--- a/backend/uasmartsignage/src/main/resources/application.properties
+++ b/backend/uasmartsignage/src/main/resources/application.properties
@@ -11,4 +11,6 @@ server.port=8080
 #Swagger
 springdoc.swagger-ui.path=/docs
 
-
+# File uploads
+spring.servlet.multipart.max-file-size=100MB
+spring.servlet.multipart.max-request-size=100MB

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -48,8 +48,8 @@ function NavBar() {
                 onMouseLeave={()=>{setIsShow(false)}}
                 >
                 <div className="w-full h-[16%] flex flex-col place-content-center font-bold">
-                    <h>UA SMART</h>
-                    <h className="ml-8">SIGNAGE</h> 
+                    <h1>UA SMART</h1>
+                    <h1 className="ml-8">SIGNAGE</h1> 
                 </div>
                 <Link to={"dashboard"} className="w-full h-[5%] flex items-center">
                     Dashboard

--- a/frontend/src/components/Portals/MediaFileModal.jsx
+++ b/frontend/src/components/Portals/MediaFileModal.jsx
@@ -2,6 +2,7 @@ import { createPortal } from 'react-dom';
 import { MdArrowBack, MdMonitor, MdCheck } from "react-icons/md";
 import { useEffect, useState } from 'react';
 import mediaService from '../../services/mediaService';
+import PropTypes from 'prop-types';
 
 function MediaFileModal({showPortal, setShowPortal, currentFolder, updater, setUpdater }){
 
@@ -62,7 +63,7 @@ function MediaFileModal({showPortal, setShowPortal, currentFolder, updater, setU
 MediaFileModal.propTypes = {
     showPortal: PropTypes.bool.isRequired,
     setShowPortal: PropTypes.func.isRequired,
-    currentFolder: PropTypes.int.isRequired,
+    currentFolder: PropTypes.number.isRequired,
     updater: PropTypes.bool.isRequired,
     setUpdater: PropTypes.func.isRequired,
 }

--- a/frontend/src/components/Portals/MediaFileModal.jsx
+++ b/frontend/src/components/Portals/MediaFileModal.jsx
@@ -1,10 +1,9 @@
 import { createPortal } from 'react-dom';
 import { MdArrowBack, MdMonitor, MdCheck } from "react-icons/md";
 import { useEffect, useState } from 'react';
-import monitorService from '../../services/monitorService';
 import mediaService from '../../services/mediaService';
 
-function MediaFileModal({showPortal, setShowPortal,currentFolder}){
+function MediaFileModal({showPortal, setShowPortal, currentFolder, updater, setUpdater }){
 
     const [file, setFile] = useState(null);
 
@@ -22,6 +21,7 @@ function MediaFileModal({showPortal, setShowPortal,currentFolder}){
         }
         
         await mediaService.createFile(formData);
+        setUpdater(!updater);
         setShowPortal(false);
     }
 

--- a/frontend/src/components/Portals/MediaFileModal.jsx
+++ b/frontend/src/components/Portals/MediaFileModal.jsx
@@ -59,4 +59,12 @@ function MediaFileModal({showPortal, setShowPortal, currentFolder, updater, setU
     )
 }
 
+MediaFileModal.propTypes = {
+    showPortal: PropTypes.bool.isRequired,
+    setShowPortal: PropTypes.func.isRequired,
+    currentFolder: PropTypes.int.isRequired,
+    updater: PropTypes.bool.isRequired,
+    setUpdater: PropTypes.func.isRequired,
+}
+
 export default MediaFileModal;

--- a/frontend/src/components/Portals/MediaFolderModal.jsx
+++ b/frontend/src/components/Portals/MediaFolderModal.jsx
@@ -51,4 +51,12 @@ function MediaFolderModal( { showPortal, setShowPortal, currentFolder, updater, 
 );
 }
 
+MediaFolderModal.propTypes = {
+    showPortal: PropTypes.bool.isRequired,
+    setShowPortal: PropTypes.func.isRequired,
+    currentFolder: PropTypes.int.isRequired,
+    updater: PropTypes.bool.isRequired,
+    setUpdater: PropTypes.func.isRequired,
+}
+
 export default MediaFolderModal;

--- a/frontend/src/components/Portals/MediaFolderModal.jsx
+++ b/frontend/src/components/Portals/MediaFolderModal.jsx
@@ -3,7 +3,7 @@ import { MdArrowBack } from "react-icons/md";
 import { useState } from 'react';
 import mediaService from '../../services/mediaService';
 
-function MediaFolderModal( { showPortal, setShowPortal, currentFolder } ) {
+function MediaFolderModal( { showPortal, setShowPortal, currentFolder, updater, setUpdater } ) {
 
     const [folderName, setFolderName] = useState(null);
 
@@ -16,6 +16,7 @@ function MediaFolderModal( { showPortal, setShowPortal, currentFolder } ) {
         }
 
         await mediaService.createFolder(folder);
+        setUpdater(!updater);
         setShowPortal(false);
     }
     return (

--- a/frontend/src/components/Portals/MediaFolderModal.jsx
+++ b/frontend/src/components/Portals/MediaFolderModal.jsx
@@ -2,6 +2,7 @@ import { createPortal } from 'react-dom';
 import { MdArrowBack } from "react-icons/md";
 import { useState } from 'react';
 import mediaService from '../../services/mediaService';
+import PropTypes from 'prop-types';
 
 function MediaFolderModal( { showPortal, setShowPortal, currentFolder, updater, setUpdater } ) {
 
@@ -54,7 +55,7 @@ function MediaFolderModal( { showPortal, setShowPortal, currentFolder, updater, 
 MediaFolderModal.propTypes = {
     showPortal: PropTypes.bool.isRequired,
     setShowPortal: PropTypes.func.isRequired,
-    currentFolder: PropTypes.int.isRequired,
+    currentFolder: PropTypes.number.isRequired,
     updater: PropTypes.bool.isRequired,
     setUpdater: PropTypes.func.isRequired,
 }

--- a/frontend/src/components/Portals/PendingMonitorsModal.jsx
+++ b/frontend/src/components/Portals/PendingMonitorsModal.jsx
@@ -3,7 +3,7 @@ import { MdArrowBack, MdMonitor, MdCheck } from "react-icons/md";
 import DataTable, { createTheme } from 'react-data-table-component';
 import { useEffect, useState } from 'react';
 import monitorService from '../../services/monitorService';
-import PropTypes from 'prop-types'
+import PropTypes from 'prop-types';
 
 
 function PendingMonitorsModal( { showPortal, setShowPortal } ) {

--- a/frontend/src/pages/Media/index.jsx
+++ b/frontend/src/pages/Media/index.jsx
@@ -45,7 +45,7 @@ function Media() {
                     <MdOutlineInsertDriveFile className="h-6 w-6 mr-2"/> Name
                 </div>
             ),
-            selector: row => {
+            selector: (row) => {
                 return(
                     <div data-tag="allowRowEvents" className="flex flex-row items-center">
                         {getFileIcon(row.type)}
@@ -103,29 +103,27 @@ function Media() {
     };
 
     const handleRowClick = (row) => {
-        switch (row.type){
-            case "directory":
-                setCurrentFolder(row.id);
-                navigate(window.location.pathname + "&" + row.name);
-                return;
-            default:
-                const change = (row.name === file ? null : row.name);
-                setFileType(row.type);
-                setFile(change);
-                if (change !== null){
-                    if (path === 'home' ){
-                        setPreview("http://localhost:8080/uploads/" + row.name);
-                    }
-                    else{
-                        // will be changed to row.path
-                        const filePath = window.location.pathname.split("/")[2].replace("&", "/").replace("home/", "") + "/" + row.name;
-                        setPreview("http://localhost:8080/uploads/" + filePath);
-                    }
+        if (row.type === "directory"){
+            setCurrentFolder(row.id);
+            navigate(window.location.pathname + "&" + row.name);
+        }
+        else{
+            const change = (row.name === file ? null : row.name);
+            setFileType(row.type);
+            setFile(change);
+            if (change !== null){
+                if (path === 'home' ){
+                    setPreview("http://localhost:8080/uploads/" + row.name);
                 }
                 else{
-                    setPreview(null);
+                    // will be changed to row.path
+                    const filePath = window.location.pathname.split("/")[2].replace("&", "/").replace("home/", "") + "/" + row.name;
+                    setPreview("http://localhost:8080/uploads/" + filePath);
                 }
-                break;
+            }
+            else{
+                setPreview(null);
+            }
         }
     };
 

--- a/frontend/src/pages/Media/index.jsx
+++ b/frontend/src/pages/Media/index.jsx
@@ -1,5 +1,5 @@
 import { PageTitle, MediaFileModal, MediaFolderModal } from '../../components';
-import { MdAdd, MdOutlineFolder, MdOutlineInsertPhoto, MdLocalMovies } from "react-icons/md";
+import { MdAdd, MdOutlineFolder, MdOutlineInsertPhoto, MdLocalMovies, MdOutlineInsertDriveFile } from "react-icons/md";
 import { useEffect, useState } from 'react';
 import DataTable from 'react-data-table-component';
 import mediaService from '../../services/mediaService';
@@ -40,18 +40,19 @@ function Media() {
 
     const columns = [
         {
-            name: `Name`,
-            header: { style: { fontSize: "72px" } },
-            selector: row => row.name,
-            cell: (row) => {
+            name: (
+                <div className="flex flex-row">
+                    <MdOutlineInsertDriveFile className="h-6 w-6 mr-2"/> Name
+                </div>
+            ),
+            selector: row => {
                 return(
-                    <div className="flex flex-row text-lg items-center">
+                    <div data-tag="allowRowEvents" className="flex flex-row items-center">
                         {getFileIcon(row.type)}
-                        <span className="ml-2">{row.name}</span>
+                        <span data-tag="allowRowEvents" className="ml-2">{row.name}</span>
                     </div>
                 )
             },
-            sortable: true,
             width: '47%',
         },
         {
@@ -61,40 +62,41 @@ function Media() {
         },
         {
             name: 'Size',
-            selector: row => row.size,
-            cell: (row) => {
-                return(
-                    <div className="flex flex-row text-lg">
-                        <span className="">{formatBytes(row.size)}</span>
-                    </div>
-                )
-            },
+            selector: row => formatBytes(row.size, 0),
             sortable: true,
             width: '25%',
         },
         {
             name: 'Date',
+            selector: row => row.date,
             sortable: true,
-            cell: (row) => {
-                return(
-                    <div className="flex flex-row text-lg">
-                        <span className="">{row.date}</span>
-                    </div>
-                )
-            },
             width: '28%',
             right: 'true',
         }
     ];
 
+    const customStyles = {
+        head: {
+            style: {
+                fontSize: '20px',
+            },
+        },
+        rows: {
+            style: {
+                fontSize: '16px',
+            },
+        },
+    };
+
+
     const getFileIcon = (type) => {
         switch (type) {
             case "directory":
-                return <MdOutlineFolder className="h-6 w-6 mr-2"/>;
+                return <MdOutlineFolder data-tag="allowRowEvents" className="h-6 w-6 mr-2"/>;
             case "image/png":
-                return <MdOutlineInsertPhoto className="h-7 w-7 mr-2"/>;
+                return <MdOutlineInsertPhoto data-tag="allowRowEvents" className="h-7 w-7 mr-2"/>;
             case "video/mp4":
-                return <MdLocalMovies className="h-6 w-6 mr-2"/>;
+                return <MdLocalMovies data-tag="allowRowEvents" className="h-6 w-6 mr-2"/>;
             default:
                 break;
         }
@@ -138,14 +140,14 @@ function Media() {
         const i = Math.floor(Math.log(bytes) / Math.log(k))
     
         return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
-    }
+    };
 
     const breadCrumbs = () => {
         return (
             <div className="flex flex-row">
                 {path.split("&").map((folder, index, array) =>
                     <div key={index}>
-                        <button onClick={() => {navigate("/media/" + folder) }}
+                        <button onClick={() => { navigate("/media/" + folder) }}
                                 onMouseOver={(e) => e.target.style.backgroundColor = 'blue'}
                                 onMouseOut={(e) => e.target.style.backgroundColor = ''}
                                 >
@@ -156,8 +158,36 @@ function Media() {
                 )}
             </div>
         )
-    }
+    };
 
+    const showText = () => {
+        return (
+            <div id="mediaTextPreview" className="m-auto mt-[25%] text-2xl font-light">
+                <span>Select a file to preview it here</span>
+            </div>
+        )
+    };
+
+    const showFilePreview = () => {
+        return (
+            fileType === "video/mp4" ? 
+            <div>
+                <span className="flex flex-row text-2xl items-center font-medium mb-3">
+                    <MdLocalMovies data-tag="allowRowEvents" className="h-8 w-8 "/> 
+                    Preview:
+                </span>
+                <video src={`${preview}`} controls muted/> 
+            </div>
+            : 
+            <div>
+                <span className="flex flex-row text-2xl items-center font-medium mb-3">
+                    <MdOutlineInsertPhoto data-tag="allowRowEvents" className="h-8 w-8"/> 
+                    Preview:
+                </span>
+                <img className=" max-h-[720px]" src={`${preview}`} alt={`${file}`}/>
+            </div>
+        )
+    }
 
     return (
         <div className="h-full flex flex-col">
@@ -206,17 +236,13 @@ function Media() {
                             pagination
                             columns={columns}
                             data={filesAndDirectories}
-                            onRowClicked={handleRowClick}/>
+                            onRowClicked={handleRowClick}
+                            customStyles={customStyles}/>
                     </div>
                     <div id="mediaDividerHr" className=" w-[1px] h-full border-[1px] border-secondary"/>
                     <div id="mediaImage" className="flex h-full w-[45%]">
                         <div id="mediaPreview" className="flex w-[40%] ml-[1%] mt-[1%] fixed justify-center items-center">
-                            {file === null ? 
-                                    "" : fileType === "video/mp4" ? 
-                                            <video src={`${preview}`} controls muted/> : <img className=" max-h-[720px]" src={`${preview}`} alt={`${file}`}/>}
-                        </div>
-                        <div id="mediaTextPreview" className="m-auto mt-[25%] text-2xl font-light">
-                            <span>Select a file to preview it here</span>
+                            {file === null ? showText() : showFilePreview()}
                         </div>
                     </div>
                 </div>

--- a/frontend/src/pages/Media/index.jsx
+++ b/frontend/src/pages/Media/index.jsx
@@ -14,6 +14,7 @@ function Media() {
 
     const [updater, setUpdater] = useState(false);
     const [file, setFile] = useState(null);
+    const [fileType, setFileType] = useState(null);
     const [preview, setPreview] = useState(null);
 
     const [showPortalFile, setShowPortalFile] = useState(false);
@@ -102,6 +103,7 @@ function Media() {
                 return;
             default:
                 const change = (row.name === file ? null : row.name);
+                setFileType(row.type);
                 setFile(change);
                 if (change !== null){
                     if (path === 'home' ){
@@ -131,6 +133,24 @@ function Media() {
         const i = Math.floor(Math.log(bytes) / Math.log(k))
     
         return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+    }
+
+    const breadCrumbs = () => {
+        return (
+            <div className="flex flex-row">
+                {path.split("&").map((folder, index, array) =>
+                    <div key={index}>
+                        <button onClick={() => {navigate("/media/" + folder) }}
+                                onMouseOver={(e) => e.target.style.backgroundColor = 'blue'}
+                                onMouseOut={(e) => e.target.style.backgroundColor = ''}
+                                >
+                                {folder}
+                        </button>
+                        {(array.length > index + 1) && <span className="pr-2 pl-2">&gt;</span>}
+                    </div>
+                )}
+            </div>
+        )
     }
 
 
@@ -168,14 +188,7 @@ function Media() {
                             updater={updater}
                             setUpdater={setUpdater}/>
                     <div className="flex items-center w-[24%] ml-6 flex-row">
-                        {path.split("&").map((folder, index) =>
-                            <button onClick={() => navigate(window.location.pathname)}
-                                    onMouseOver={(e) => e.target.style.backgroundColor = 'blue'}
-                                    onMouseOut={(e) => e.target.style.backgroundColor = ''}
-                                     key={index}>
-                                        {folder}
-                            </button>
-                        )}
+                        {breadCrumbs()}
                     </div>
                 </div>
                 <div id="dividerHr" className="border-[1px] border-secondary"/>
@@ -192,7 +205,9 @@ function Media() {
                     <div id="mediaDividerHr" className=" w-[1px] h-full border-[1px] border-secondary"/>
                     <div id="mediaImage" className="flex h-full w-[45%]">
                         <div id="mediaPreview" className="flex h-[60%] w-[40%] ml-[1%] mt-[1%] fixed justify-center items-center">
-                            {file === null ? "" : <img className="h-full w-full" src={`${preview}`} alt={`${file}`}/>}
+                            {file === null ? 
+                                    "" : fileType === "video/mp4" ? 
+                                            <video  src={`${preview}`} controls muted/> : <img className="h-full w-full" src={`${preview}`} alt={`${file}`}/>}
                         </div>
                         <div id="mediaTextPreview" className="m-auto mt-[25%] text-2xl font-light">
                             <span>Select a file to preview it here</span>

--- a/frontend/src/pages/Media/index.jsx
+++ b/frontend/src/pages/Media/index.jsx
@@ -45,14 +45,7 @@ function Media() {
                     <MdOutlineInsertDriveFile className="h-6 w-6 mr-2"/> Name
                 </div>
             ),
-            selector: (row) => {
-                return(
-                    <div data-tag="allowRowEvents" className="flex flex-row items-center">
-                        {getFileIcon(row.type)}
-                        <span data-tag="allowRowEvents" className="ml-2">{row.name}</span>
-                    </div>
-                )
-            },
+            selector: row => headNameStyle(row),
             width: '47%',
         },
         {
@@ -88,6 +81,15 @@ function Media() {
         },
     };
 
+
+    const headNameStyle = (row) => {
+        return(
+            <div data-tag="allowRowEvents" className="flex flex-row items-center">
+                {getFileIcon(row.type)}
+                <span data-tag="allowRowEvents" className="ml-2">{row.name}</span>
+            </div>
+        )
+    };
 
     const getFileIcon = (type) => {
         switch (type) {
@@ -144,11 +146,8 @@ function Media() {
         return (
             <div className="flex flex-row">
                 {path.split("&").map((folder, index, array) =>
-                    <div key={index}>
-                        <button onClick={() => { navigate("/media/" + folder) }}
-                                onMouseOver={(e) => e.target.style.backgroundColor = 'blue'}
-                                onMouseOut={(e) => e.target.style.backgroundColor = ''}
-                                >
+                    <div>
+                        <button key={index} onClick={() => { navigate("/media/" + folder) }}>
                                 {folder}
                         </button>
                         {(array.length > index + 1) && <span className="pr-2 pl-2">&gt;</span>}

--- a/frontend/src/pages/Media/index.jsx
+++ b/frontend/src/pages/Media/index.jsx
@@ -55,6 +55,11 @@ function Media() {
             width: '47%',
         },
         {
+            id: 'isFolder',
+            selector: row => row.type,
+            omit: true,
+        },
+        {
             name: 'Size',
             selector: row => row.size,
             cell: (row) => {
@@ -195,6 +200,7 @@ function Media() {
                 <div className="h-[94%] flex flex-row">
                     <div id="mediaContent" className="flex flex-col w-[50%] ml-[4%] overflow-scroll max-h-[760px]">
                         <DataTable className="p-3" 
+                            defaultSortFieldId="isFolder"
                             pointerOnHover
                             highlightOnHover
                             pagination
@@ -204,10 +210,10 @@ function Media() {
                     </div>
                     <div id="mediaDividerHr" className=" w-[1px] h-full border-[1px] border-secondary"/>
                     <div id="mediaImage" className="flex h-full w-[45%]">
-                        <div id="mediaPreview" className="flex h-[60%] w-[40%] ml-[1%] mt-[1%] fixed justify-center items-center">
+                        <div id="mediaPreview" className="flex w-[40%] ml-[1%] mt-[1%] fixed justify-center items-center">
                             {file === null ? 
                                     "" : fileType === "video/mp4" ? 
-                                            <video  src={`${preview}`} controls muted/> : <img className="h-full w-full" src={`${preview}`} alt={`${file}`}/>}
+                                            <video src={`${preview}`} controls muted/> : <img className=" max-h-[720px]" src={`${preview}`} alt={`${file}`}/>}
                         </div>
                         <div id="mediaTextPreview" className="m-auto mt-[25%] text-2xl font-light">
                             <span>Select a file to preview it here</span>


### PR DESCRIPTION
### Issue

Closes #84 

### Reason for this change

Our media page had very limited functionality so this PR aims to change that along with some other small things.

### Description of changes

- Changed table style
- Added preview functionality for both images and videos
- Added file cache
- Changed a template to better show the difference during presentation
- Added 100MB file limit upload (can be changed as needed)
- Fixed small html tag error on sidebar
- Added auto-reload to the data table whenever we create something new

### Description of how you validated changes

Tried with few images and videos, even going inside folders.

### Checklist
- [X] I have tested my changes locally.
- [ ] I have updated the documentation to reflect my changes.
- [ ] I have added/updated unit tests (if applicable).
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://ua-smart-signage-platform.github.io/Documentation-Website/guidelines/)

### Aditional Information


