### PR TITLE
Add delete group functionality

### DIFF
--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Models/MonitorsGroup.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Models/MonitorsGroup.java
@@ -27,7 +27,7 @@ public class MonitorsGroup {
     @Column
     private String description;
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "group")
     @JsonIgnoreProperties("group")
     private List<Monitor> monitors;
 

--- a/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Services/MonitorService.java
+++ b/backend/uasmartsignage/src/main/java/deti/uas/uasmartsignage/Services/MonitorService.java
@@ -39,12 +39,13 @@ public class MonitorService {
     public Monitor updateMonitor(Long id, Monitor monitor) {
         Monitor monitorById = monitorRepository.getReferenceById(id);
         MonitorsGroup group = monitorById.getGroup();
+        monitorById.setName(monitor.getName());
+        monitorById.setGroup(monitor.getGroup());
+        Monitor returnMonitor = monitorRepository.save(monitorById);
         if (group.isMadeForMonitor()) {
             monitorGroupRepository.deleteById(group.getId());
         }
-        monitorById.setName(monitor.getName());
-        monitorById.setGroup(monitor.getGroup());
-        return monitorRepository.save(monitorById);
+        return returnMonitor;
     }
 
     public Monitor updatePending(Long id,boolean pending){

--- a/frontend/src/components/GroupBar/index.jsx
+++ b/frontend/src/components/GroupBar/index.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { MdSettings, MdCreate, MdAdd, MdCheck } from "react-icons/md";
+import { IoMdTrash } from "react-icons/io";
 import monitorsGroupService from "../../services/monitorsGroupService"
 import {motion} from "framer-motion"
 
@@ -9,7 +10,7 @@ function GroupBar( {id, changeId, page} ) {
     const [editGroup,setEditGroup] = useState({id:-1,name:"",description:""});
  
     useEffect(() => {
-        monitorsGroupService.getGroups().then((groupsData) => {
+        monitorsGroupService.getGroupsNotMadeForMonitor().then((groupsData) => {
             setGroups(groupsData.data);
         })
     }, []);
@@ -45,20 +46,29 @@ function GroupBar( {id, changeId, page} ) {
     const handleUpdateCreate = () =>{
         if (editGroup.id < 0){
             monitorsGroupService.createGroup(editGroup).then((response) =>{
-                monitorsGroupService.getGroups().then((groupsData) => {
+                monitorsGroupService.getGroupsNotMadeForMonitor().then((groupsData) => {
                     setGroups(groupsData.data);
                 })
             })
         }
         else{
             monitorsGroupService.updateGroup(editGroup.id,editGroup).then((response) =>{
-                monitorsGroupService.getGroups().then((groupsData) => {
+                monitorsGroupService.getGroupsNotMadeForMonitor().then((groupsData) => {
                     setGroups(groupsData.data);
                 })
             })
 
         }
         setEditGroup({id:-1,name:"",description:""})
+    }
+
+    const handleDelete = (id) =>{
+        monitorsGroupService.deleteGroup(id).then((response) =>{
+            monitorsGroupService.getGroupsNotMadeForMonitor().then((groupsData) => {
+                setGroups(groupsData.data);
+            })
+        })
+        setGroups(groups.filter((element) => element.id !== id))
     }
 
     const handleBlur = (e) => {
@@ -132,14 +142,19 @@ function GroupBar( {id, changeId, page} ) {
                                 {editMode &&
                                     <div className="ml-auto">
                                         {editGroup.id !== group.id ? 
-                                        <MdCreate className="h-5 w-5 cursor-pointer" onClick={()=>setEditGroup(group)}/> :
+                                        <div className="flex gap-1">
+                                            <button onClick={()=>setEditGroup(group)}><MdCreate className="h-5 size-5 cursor-pointer"/></button>
+                                            <button onClick={() => handleDelete(group.id)}><IoMdTrash className="h-5 size-5 cursor-pointer"/></button>
+                                        </div> 
+                                        :
                                         <button><MdCheck className="size-5" onClick={() => handleUpdateCreate()}/></button>
                                     }
                                     </div>
                                 }
                             </div>
                             {editGroup.id !== group.id ? 
-                                        <span className="text-sm">{group.description}</span> :
+                                        <span className="text-sm">{group.description}</span> 
+                                        :
                                         <input className=" bg-white rounded-md w-full text-sm px-2" value={editGroup.description} onChange={(e)=>editGroupDescription(e.target.value)}/>
                                     }
                         </div>

--- a/frontend/src/pages/Monitor/index.jsx
+++ b/frontend/src/pages/Monitor/index.jsx
@@ -21,7 +21,7 @@ function Monitor(){
             setName(response.data.name)
             setGroupId(response.data.group.id)
         })
-        monitorsGroupService.getGroups().then((response)=>{
+        monitorsGroupService.getGroupsNotMadeForMonitor().then((response)=>{
             setGroups(response.data)
         })
     },[])
@@ -74,7 +74,7 @@ function Monitor(){
                                 <div className="flex w-full gap-3 h-[49%] justify-around">
                                     <div className=" bg-secondaryMedium rounded-[10px] rounded-tl-[30px] basis-1/3 flex flex-col items-center p-2 h-full"> 
                                         <div className="h-[20%]">Memory</div>
-                                        <MemorySvg className=" h-[80%]" usado={"120"} max={`${monitor.size}`} full={0.5}/>
+                                        <MemorySvg className=" h-[80%]" usado={"120"} max={"200"} full={0.8}/>
                                     </div>
                                     <div className=" bg-secondaryMedium rounded-[10px] basis-1/3 p-2"> 
                                         <div className="h-[20%]">
@@ -96,7 +96,7 @@ function Monitor(){
                                                 )}
                                                 </select>
                                                 :
-                                                <span className="text-xl text-center w-full">{monitor.group.name}</span>
+                                                <span className="text-xl text-center w-full">{!monitor.group.madeForMonitor ? monitor.group.name:"----"}</span>
                                             }
                                         </div>
                                     </div>

--- a/frontend/src/pages/Monitors/index.jsx
+++ b/frontend/src/pages/Monitors/index.jsx
@@ -75,7 +75,7 @@ function Monitors(){
         },
         {
             name: 'Group',
-            selector: row => row.group.name,
+            selector: row => !row.group.madeForMonitor ? row.group.name:"-----",
             sortable: true,
         },
         {

--- a/frontend/src/services/monitorsGroupService.jsx
+++ b/frontend/src/services/monitorsGroupService.jsx
@@ -9,6 +9,12 @@ const monitorsGroupService = {
     },
     async updateGroup(id,group){
         return await client.put(`/groups/${id}`,group)
+    },
+    async deleteGroup(id){
+        return await client.delete(`/groups/${id}`)
+    },
+    async getGroupsNotMadeForMonitor(){
+        return await client.get("/groups/notMadeForMonitor");
     }
 }
 


### PR DESCRIPTION
### Issue

Closes #97 

### Reason for this change

this change was so the user can delete a monitor group

### Description of changes

In the page monitors group was added a button, in edit mode, to delete a group, when group is deleted their monitors go to their respective deafault group.
In the backend the model groupMonitor was changed cascade.all removed because it was deleting the monitors
the service update monitor was updated because it tried to delete the group before putting new group in monitor, and it was giving error of key.

### Description of how you validated changes

tested interaction in frontend

### Checklist
- [x] I have tested my changes locally.
- [ ] I have updated the documentation to reflect my changes.
- [ ] I have added/updated unit tests (if applicable).
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://ua-smart-signage-platform.github.io/Documentation-Website/guidelines/)

### Aditional Information


