### PR TITLE
Fix select dropdown, size UI and date picker bug

### DIFF
--- a/frontend/src/components/Portals/ScheduleModal.jsx
+++ b/frontend/src/components/Portals/ScheduleModal.jsx
@@ -143,6 +143,7 @@ function ScheduleModal( { setShowPortal, selectedGroup } ) {
             );
         }
     }
+    
     return createPortal(
             <motion.div key="background"
                     initial={{ opacity: 0 }}

--- a/frontend/src/components/Portals/ScheduleModal.jsx
+++ b/frontend/src/components/Portals/ScheduleModal.jsx
@@ -125,13 +125,16 @@ function ScheduleModal( { setShowPortal, selectedGroup } ) {
         } 
         else if (templateWidget.widget.contents.length > 0) {
             return (
-                <Select
-                    className="z-20"
-                    placeholder={templateWidget.widget.name + "..."}
-                    isSearchable="true"
-                    onChange={(e) => handleSelectedContent(e)}
-                    options={templateWidget.widget.contents[0].options.map(option => ({ value: templateWidget.widget.id, label: option }))}
-                />
+                <div className="text-sm min-w-[90%] max-w-[90%]">
+                    <Select
+                        className="z-20"
+                        placeholder={templateWidget.widget.name + "..."}
+                        isSearchable="true"
+                        onChange={(e) => handleSelectedContent(e)}
+                        options={templateWidget.widget.contents[0].options.map(option => ({ value: templateWidget.widget.id, label: option }))}
+                        getOptionValue={(option) => option.label}
+                    />
+                </div>
             );
         } 
         else {
@@ -140,7 +143,8 @@ function ScheduleModal( { setShowPortal, selectedGroup } ) {
             );
         }
     }
-
+console.log("hhhhhh");
+//console.log(templates[0].templateWidgets[0].widget.contents[0].options);
     return createPortal(
             <motion.div key="background"
                     initial={{ opacity: 0 }}
@@ -305,7 +309,7 @@ function ScheduleModal( { setShowPortal, selectedGroup } ) {
                                                             <DatePicker 
                                                                 onChange={(date) => setSelectedEndDate(date)} 
                                                                 value={selectedEndDate} 
-                                                                minDate={new Date()}
+                                                                minDate={selectedStartDate !== null ? selectedStartDate : new Date()}
                                                                 format="dd/MM/y"/>
                                                         </div>
                                                     </div>

--- a/frontend/src/components/Portals/ScheduleModal.jsx
+++ b/frontend/src/components/Portals/ScheduleModal.jsx
@@ -143,8 +143,6 @@ function ScheduleModal( { setShowPortal, selectedGroup } ) {
             );
         }
     }
-console.log("hhhhhh");
-//console.log(templates[0].templateWidgets[0].widget.contents[0].options);
     return createPortal(
             <motion.div key="background"
                     initial={{ opacity: 0 }}


### PR DESCRIPTION
### Issue

Closes #110 

### Reason for this change

- When we selected an item from the select dropdown it would highlight every single item instead of solely selecting the desired one.
- When we selected an item with a long name, the UI format would be overwritten and malfunction.
- Picking a starting date implied that you could select a end date BEFORE the start date.

### Description of changes

Small changes to UI logic.

### Description of how you validated changes

Tested interaction between components.

### Checklist
- [X] I have tested my changes locally.
- [ ] I have updated the documentation to reflect my changes.
- [ ] I have added/updated unit tests (if applicable).
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://ua-smart-signage-platform.github.io/Documentation-Website/guidelines/)

### Aditional Information
N/A

