### PR TITLE
Update monitors list automatically and allow user to refresh pending list

### DIFF
--- a/frontend/src/components/PageTitle/EndTitleHtml.jsx
+++ b/frontend/src/components/PageTitle/EndTitleHtml.jsx
@@ -2,7 +2,7 @@ import { MdOutlineSearch, MdAdd } from "react-icons/md";
 import PendingMonitorsModal from "../Portals/PendingMonitorsModal";
 import { useState } from "react";
 
-function EndTitleHtml( { page } ) {
+function EndTitleHtml( { page, updater, setUpdater } ) {
     const [showPortal, setShowPortal] = useState(false);
     
     if (page === "default")
@@ -23,7 +23,7 @@ function EndTitleHtml( { page } ) {
                     <MdAdd className="h-6 w-6 mr-1 ml-1"/>
                     <span>Pending Monitors</span>
                 </button>
-                <PendingMonitorsModal showPortal={showPortal} setShowPortal={setShowPortal}/>
+                <PendingMonitorsModal showPortal={showPortal} setShowPortal={setShowPortal} monitorsUpdater={updater} setMonitorsUpdater={setUpdater}/>
             </div>
         )
     if (page === "...")

--- a/frontend/src/components/PageTitle/EndTitleHtml.jsx
+++ b/frontend/src/components/PageTitle/EndTitleHtml.jsx
@@ -31,4 +31,11 @@ function EndTitleHtml( { page, updater, setUpdater } ) {
             <div></div>
         )
 }
+
+EndTitleHtml.propTypes = {
+    page: PropTypes.string.isRequired,
+    updater: PropTypes.bool.isRequired,
+    setUpdater: PropTypes.func.isRequired
+}
+
 export default EndTitleHtml

--- a/frontend/src/components/PageTitle/index.jsx
+++ b/frontend/src/components/PageTitle/index.jsx
@@ -1,6 +1,7 @@
 import EndTitleHtml from './EndTitleHtml';
 import MiddleTitleHtml from './MiddleTitleHtml';
 import StartTitleHtml from './StartTitleHtml';
+import PropTypes from 'prop-types';
 
 function PageTitle({ startTitle, middleTitle, endTitle, updater, setUpdater }) {
     return (
@@ -19,6 +20,14 @@ function PageTitle({ startTitle, middleTitle, endTitle, updater, setUpdater }) {
             <div id="dividerHr" className="border-[1px] border-secondary flex-col"/>
         </div>
     )
+}
+
+PageTitle.propTypes = {
+    startTitle: PropTypes.string.isRequired,
+    middleTitle: PropTypes.string.isRequired,
+    endTitle: PropTypes.string.isRequired,
+    updater: PropTypes.bool.isRequired,
+    setUpdater: PropTypes.func.isRequired
 }
 
 export default PageTitle;

--- a/frontend/src/components/PageTitle/index.jsx
+++ b/frontend/src/components/PageTitle/index.jsx
@@ -2,7 +2,7 @@ import EndTitleHtml from './EndTitleHtml';
 import MiddleTitleHtml from './MiddleTitleHtml';
 import StartTitleHtml from './StartTitleHtml';
 
-function PageTitle({ startTitle, middleTitle, endTitle }) {
+function PageTitle({ startTitle, middleTitle, endTitle, updater, setUpdater }) {
     return (
         <div className="flex flex-col h-full">
             <div id="centerItems" className="items-end h-full w-full flex">
@@ -13,7 +13,7 @@ function PageTitle({ startTitle, middleTitle, endTitle }) {
                     <MiddleTitleHtml page={middleTitle} />
                 </div>
                 <div id="endTitle" className="flex ml-auto mb-3 mr-1">
-                    < EndTitleHtml page={endTitle} />
+                    < EndTitleHtml page={endTitle} updater={updater} setUpdater={setUpdater} />
                 </div>
             </div>
             <div id="dividerHr" className="border-[1px] border-secondary flex-col"/>

--- a/frontend/src/components/Portals/PendingMonitorsModal.jsx
+++ b/frontend/src/components/Portals/PendingMonitorsModal.jsx
@@ -1,27 +1,29 @@
 import { createPortal } from 'react-dom';
-import { MdArrowBack, MdMonitor, MdCheck } from "react-icons/md";
-import DataTable, { createTheme } from 'react-data-table-component';
+import { MdArrowBack, MdCheck } from "react-icons/md";
+import DataTable from 'react-data-table-component';
 import { useEffect, useState } from 'react';
 import monitorService from '../../services/monitorService';
 import PropTypes from 'prop-types';
+import { motion } from 'framer-motion';
 
 
-function PendingMonitorsModal( { showPortal, setShowPortal } ) {
+function PendingMonitorsModal( { showPortal, setShowPortal, monitorsUpdater, setMonitorsUpdater } ) {
 
     const [pendingMonitors,setPendingMonitor] = useState([]);
     const [updater,setUpdater] = useState(false);
+    const [disabled, setDisabled] = useState(false);
 
     useEffect(()=>{
-        monitorService.getPendingMonitors().then((response)=>{
+        monitorService.getPendingMonitors().then((response) => {
             setPendingMonitor(response.data)
         })
     },[updater])
 
     const handleAccept = (id)=>{
-        monitorService.acceptMonitor(id).then((response)=>{
-            setUpdater(updater ? setUpdater(false):setUpdater(true));
+        monitorService.acceptMonitor(id).then(() => {
+            setUpdater(!updater);
+            setPendingMonitor(pendingMonitors.filter(a=> a.id !== id));
         });
-        setPendingMonitor(pendingMonitors.filter(a=> a.id !== id));
     }
 
     const columns = [
@@ -39,6 +41,15 @@ function PendingMonitorsModal( { showPortal, setShowPortal } ) {
         },
     ];
 
+    const handleRefresh = () => {
+        setUpdater(!updater);
+        setDisabled(true);
+    
+        setTimeout(() => {
+          setDisabled(false);
+        }, 3000);
+    };
+
     return (
     <>
         {showPortal && createPortal(
@@ -47,14 +58,26 @@ function PendingMonitorsModal( { showPortal, setShowPortal } ) {
                 <div className="absolute text-gray-50 h-screen w-screen flex items-center">
                     <div className="bg-[#fafdf7] text-[#101604] h-[75%] w-[70%] mx-auto rounded-xl p-[2%]">
                         <div className="h-[5%] flex items-center">
-                            <button onClick={() => setShowPortal(false)} className="flex flex-row">
+                            <button onClick={() => {setShowPortal(false); setMonitorsUpdater(!monitorsUpdater)}} className="flex flex-row">
                                 <MdArrowBack className="w-7 h-7 mr-2"/> 
                                 <span className="text-xl">Go back</span>
                             </button>
                         </div>
                         <div className="h-[90%] p-[4%]">
-                            <div className="h-[20%] font-bold text-3xl">
-                                Pending Monitors
+                            <div className="flex h-[20%] font-bold text-3xl">
+                                <div className="w-[70%] h-full">
+                                    <span>Pending Monitors</span>
+                                </div>
+                                <div className="w-[30%] h-full text-lg font-normal relative text-end">
+                                    <motion.button
+                                        whileTap={disabled ? {} : { scale: 0.9 }}
+                                        whileHover={disabled ? {} : { scale: 1.1 }}
+                                        onClick={handleRefresh} 
+                                        disabled={disabled}
+                                        className={`bg-[#d7dad6] p-2 pr-4 pl-4 rounded-md ${disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer opacity-100"}`}>
+                                        Refresh
+                                    </motion.button>
+                                </div>
                             </div>
                             <div className="h-[80%] p-[2%] text-lg flex flex-col">
                             <DataTable className="p-3" 

--- a/frontend/src/components/Portals/PendingMonitorsModal.jsx
+++ b/frontend/src/components/Portals/PendingMonitorsModal.jsx
@@ -99,7 +99,9 @@ function PendingMonitorsModal( { showPortal, setShowPortal, monitorsUpdater, set
 
 PendingMonitorsModal.propTypes = {
     showPortal: PropTypes.bool.isRequired,
-    setShowPortal: PropTypes.func.isRequired
+    setShowPortal: PropTypes.func.isRequired,
+    monitorsUpdater: PropTypes.bool.isRequired,
+    setMonitorsUpdater: PropTypes.func.isRequired
 }
 
 export default PendingMonitorsModal;

--- a/frontend/src/pages/Monitors/index.jsx
+++ b/frontend/src/pages/Monitors/index.jsx
@@ -1,14 +1,13 @@
 import { useEffect, useState } from "react";
-import { PageTitle, GroupBar, MonitorRow } from "../../components";
-import { ReactComponent as MonitorsIcon } from "../../static/monitors.svg"
+import { PageTitle, GroupBar } from "../../components";
 import monitorService from "../../services/monitorService"
-import monitorsGroupService from "../../services/monitorsGroupService"
-import { Link, useNavigate } from "react-router-dom";
-import DataTable, { createTheme } from 'react-data-table-component';
+import { useNavigate } from "react-router-dom";
+import DataTable from 'react-data-table-component';
 
 function Monitors(){
     const [monitors, setMonitors] = useState([]);
     const [groupId, setGroupId] = useState(null);
+    const [updater, setUpdater] = useState(false);
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -23,7 +22,7 @@ function Monitors(){
             })
         }
 
-    }, [groupId]);
+    }, [groupId, updater]);
 
 
     const customStyles = {
@@ -76,27 +75,6 @@ function Monitors(){
             sortable: true
         }   
     ];
-
-
-    // keeping this code here as a reference
-    /*
-    <div id="content" className="w-full pr-3 pl-3 flex flex-col">
-    <div id="Title_Row" className="text-2xl flex px-3 pt-3 justify-items-center text-center mt-1 mb-2">
-        <span className="flex gap-2 items-center w-[40%]"><MonitorsIcon className="size-8"/>All Monitors</span>
-        <span className="text-center">Group</span>
-        <span className="ml-auto w-[10%]">Warnings</span>
-        <span className="w-[10%]">Status</span>
-        <span className="w-[10%] text-right">IP</span>
-    </div>
-    <div className="overflow-scroll">
-        {monitors != [] && monitors.map((monitor,index)=>
-            <Link to={`/monitor/${monitor.id}`} state={{ monitor:monitor}}>
-                <MonitorRow monitor={monitor} index={index}/>
-            </Link>
-        )}
-    </div>
-</div>
-    */
     
 
     return(
@@ -104,7 +82,9 @@ function Monitors(){
             <div id="title" className="pt-4 h-[8%]">
                 <PageTitle startTitle={"monitors"} 
                             middleTitle={"dashboard"}
-                            endTitle={"monitors"}/>
+                            endTitle={"monitors"}
+                            updater={updater}
+                            setUpdater={setUpdater}/>
             </div>
             <div id="divider" className="flex flex-row overflow-hidden h-[92%]">
                 <div className="w-[30%] flex flex-col">


### PR DESCRIPTION
### Issue

Closes #129 

### Reason for this change

When accepting a pending monitor the list wasn't updating automatically which was annoying and not-user-friendly.
To refresh the pending monitors list we had to press F5, which is not intuitive for our users.

### Description of changes

- Added refresh button to monitors pending modal
- Added useState to signal list to update in the monitors page

### Description of how you validated changes

Tested logic and checked if both visuals and backend worked.

### Checklist
- [X] I have tested my changes locally.
- [ ] I have updated the documentation to reflect my changes.
- [ ] I have added/updated unit tests (if applicable).
- [X] My code adheres to the [CONTRIBUTING GUIDE](https://ua-smart-signage-platform.github.io/Documentation-Website/guidelines/)

### Aditional Information
This does not address the fetch of monitor status!!

